### PR TITLE
Import objects attached to profiles

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -45,7 +45,7 @@ use Cake\Routing\RouteBuilder;
 return static function (RouteBuilder $routes): void {
     $routes->setRouteClass(DashedRoute::class);
 
-    $routes->scope('/_staging', function (RouteBuilder $builder) {
+    $routes->scope('/_staging', function (RouteBuilder $builder): void {
         $builder->connect('/clear-cache', [
             'controller' => 'Staging',
             'action' => 'clearCache',

--- a/src/Command/ImportOld.php
+++ b/src/Command/ImportOld.php
@@ -579,6 +579,13 @@ class ImportOld extends Command
             return false;
         }
 
+        $profile = $this->importRelation('attached_to', 'has_media', $data['original_id'], $profile, true);
+        if ($profile === false) {
+            $this->io->warning(sprintf('One or more attaches of profile "%s" had an error, skipping import of the profile', $data['original_uname']));
+
+            return false;
+        }
+
         return $this->importTranslations($data['original_id'], $profile);
     }
 

--- a/src/Controller/StagingController.php
+++ b/src/Controller/StagingController.php
@@ -13,8 +13,6 @@ use Cake\Http\Response;
  */
 class StagingController extends AppController
 {
-    protected $defaultTable = false;
-
     /**
      * Clear application cache.
      *


### PR DESCRIPTION
Although the `importRelation` method's documentation states that it should not be used to import the `attached_to` relation, it's already in use for galleries. The dedicated `importAttaches` method would take care of placeholders, but it's not something we're really interested in when talking about Profiles. So, I preferred using the same approach as the Galleries for the sake of simplicity.

We should re-execute this command… @le0m can you take a look at this? Is it safe to re-execute the import command for the `illustratorium` section?