### PR TITLE
Canonical urls

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -189,6 +189,14 @@ return [
             'serialize' => true,
             'duration' => '+1 year',
         ],
+
+        'canonical_urls' => [
+            'className' => FileEngine::class,
+            'prefix' => 'canonical_urls_',
+            'path' => CACHE . 'canonical_urls/',
+            'serialize' => true,
+            'duration' => '+30 seconds',
+        ],
     ],
 
     /*

--- a/deploy/app_local.php
+++ b/deploy/app_local.php
@@ -126,6 +126,16 @@ return [
             'port' => env('CACHE_REDIS_PORT', 6379),
             'database' => 0,
         ],
+
+        'canonical_urls' => [
+            'className' => RedisEngine::class,
+            'host' => env('CACHE_REDIS_HOST', null),
+            'port' => env('CACHE_REDIS_PORT', 6379),
+            'database' => 0,
+            'prefix' => 'canonical_urls_',
+            'serialize' => true,
+            'duration' => '+1 day',
+        ],
     ],
 
     'Session' => [

--- a/plugins/Chialab/src/Controller/AppController.php
+++ b/plugins/Chialab/src/Controller/AppController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Chialab\Controller;
 
 use App\Controller\AppController as BaseController;
+use BEdita\Core\Model\Entity\ObjectEntity;
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
@@ -62,6 +63,11 @@ class AppController extends BaseController
             ],
             'cache' => sprintf('publication_%s', $locale),
         ]);
+
+        $isStaging = Configure::read('StagingSite', false);
+        $this->loadComponent('CanonicalUrl', [
+            'propertyName' => $isStaging ? 'staging_url' : 'public_url',
+        ]);
     }
 
     /**
@@ -92,5 +98,14 @@ class AppController extends BaseController
         });
 
         $this->set(compact('menu', 'footerChildren', 'analytics', 'locale', 'locales'));
+
+        // Find main object's canonical URL
+        $object = $this->viewBuilder()->getVar('object');
+        if ($object instanceof ObjectEntity) {
+            $canonicalFrontendUrl = $this->CanonicalUrl->buildCanonicalUrl($object);
+            if ($canonicalFrontendUrl !== null) {
+                $this->set('canonicalUrl', $canonicalFrontendUrl);
+            }
+        }
     }
 }

--- a/plugins/Chialab/src/Controller/AppController.php
+++ b/plugins/Chialab/src/Controller/AppController.php
@@ -19,7 +19,8 @@ use Cake\I18n\I18n;
  * @property \Chialab\FrontendKit\Controller\Component\ObjectsComponent $Objects
  * @property \Chialab\FrontendKit\Controller\Component\MenuComponent $Menu
  * @property \Chialab\FrontendKit\Controller\Component\PublicationComponent $Publication
- * @property \Authentication\Controller\Component\AuthenticationComponent|null $Authentication
+ * @property \App\Controller\Component\CanonicalUrlComponent $CanonicalUrl
+ * @property \Authentication\Controller\Component\AuthenticationComponent|null
  */
 class AppController extends BaseController
 {

--- a/plugins/Chialab/src/Controller/PagesController.php
+++ b/plugins/Chialab/src/Controller/PagesController.php
@@ -6,9 +6,7 @@ namespace Chialab\Controller;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
-use Cake\Routing\Router;
 use Chialab\FrontendKit\Model\ObjectsLoader;
-use Chialab\FrontendKit\Routing\Route\ObjectRoute;
 use Chialab\FrontendKit\Traits\GenericActionsTrait;
 
 /**
@@ -18,7 +16,7 @@ class PagesController extends AppController
 {
     use GenericActionsTrait {
         fallback as private _fallback;
-        renderObject as private _renderObject;
+        object as private _object;
     }
 
     /**
@@ -153,34 +151,13 @@ class PagesController extends AppController
     public function object(string $uname): Response|null
     {
         $entity = $this->Objects->loadObject($uname, 'objects', [], []);
-        $currentRoute = $this->getRequest()->getParam('_matchedRoute');
-        $locale = $this->getRequest()->getParam('locale', null);
-        $params = array_filter(compact('locale'));
-
-        foreach (Router::routes() as $route) {
-            if (!$route instanceof ObjectRoute || $currentRoute === $route->template) {
-                continue;
-            }
-
-            $out = $route->match(['_entity' => $entity] + $route->defaults + $params, []);
-            if ($out !== null) {
-                return $this->redirect($out);
-            }
-        }
-
         $paths = $this->Publication->getViablePaths($entity->id);
-        if (!empty($paths)) {
-            return $this->redirect(['action' => 'fallback', $paths[0]['path']] + $params);
-        }
-
         $url = $this->CanonicalUrl->buildCanonicalUrl($entity);
-        if ($url !== null) {
+        if (empty($paths) && $url !== null) {
             return $this->redirect($url);
         }
 
-        throw new RecordNotFoundException();
-
-        return $this->_renderObject($entity);
+        return $this->_object($uname);
     }
 
     /**

--- a/plugins/Chialab/src/Controller/PagesController.php
+++ b/plugins/Chialab/src/Controller/PagesController.php
@@ -164,6 +164,19 @@ class PagesController extends AppController
                 $object = $this->Objects->loadObject($object);
 
                 // If we reach this point, the object does exist, but the path at which it was being accessed was wrong.
+                // Check if the object is in the current publication's tree.
+                $paths = $this->Publication->getViablePaths($object->id);
+                if (empty($paths)) {
+                    // the object isn't in the current publication. try to get its canonical URL
+                    $url = $this->CanonicalUrl->buildCanonicalUrl($object);
+
+                    if ($url !== null) {
+                        return $this->redirect($url);
+                    }
+
+                    throw $e;
+                }
+
                 // Try to redirect to `/objects/{object}` to see if we can display it somehow.
                 return $this->redirect(['_name' => 'pages:objects', 'uname' => $object->uname]);
             } catch (RecordNotFoundException $err) {

--- a/plugins/Chialab/templates/element/staging-bar.twig
+++ b/plugins/Chialab/templates/element/staging-bar.twig
@@ -4,7 +4,23 @@
         {% set name = Identity.get('name') ? Identity.get('name') ~ ' ' ~ Identity.get('surname') : Identity.get('username') %}
         <span>Accesso effettuato come: {{ name }}</span>
         {% if object is defined %}
-            <a is="dna-button-link" variant="secondary" title="edit this {{ object.type }}" class="sans" target="_blank" href="{{ url }}">Vedi in BEdita</a>
+            <a is="dna-button-link"
+                variant="secondary"
+                title="edit this {{ object.type }}"
+                class="sans"
+                target="_blank"
+                href="{{ url }}">
+                Vedi in BEdita
+            </a>
+        {% endif %}
+        {% if canonicalUrl is defined %}
+            <a is="dna-button-link"
+                variant="secondary"
+                class="sans"
+                href="{{ canonicalUrl|escape('html_attr') }}"
+                target="_blank">
+                URL canonico
+            </a>
         {% endif %}
         {{ Form.postLink('Clear cache', { _name: 'staging:clearCache' }, {
             class: 'sans',

--- a/plugins/Chialab/templates/layout/default.twig
+++ b/plugins/Chialab/templates/layout/default.twig
@@ -19,6 +19,10 @@
             'link': "#{_view.theme}.apple-touch-icon.png"
         })|raw }}
 
+        {% if canonicalUrl is defined -%}
+            <link rel="canonical" href="{{ canonicalUrl }}" />
+        {% endif %}
+
         {{ Rna.devServer(_view.theme)|raw }}
         {{ Rna.css("#{_view.theme}.index", { block: true })|raw }}
         {{ Rna.script("#{_view.theme}.index", { block: true })|raw }}

--- a/plugins/Illustratorium/src/View/Cell/IllustratorsCell.php
+++ b/plugins/Illustratorium/src/View/Cell/IllustratorsCell.php
@@ -21,6 +21,10 @@ class IllustratorsCell extends Cell
      */
     protected ObjectsLoader $loader;
 
+    protected $_validCellOptions = ['locale'];
+
+    protected $locale;
+
     /**
      * @inheritDoc
      */
@@ -29,6 +33,7 @@ class IllustratorsCell extends Cell
         parent::initialize();
 
         $this->loader = new ObjectsLoader();
+        $this->set(['locale' => $this->locale]);
     }
 
     /**
@@ -136,5 +141,4 @@ class IllustratorsCell extends Cell
     {
         $this->loadIllustratorsData(null, false);
     }
-
 }

--- a/plugins/Illustratorium/templates/Pages/illustrators.twig
+++ b/plugins/Illustratorium/templates/Pages/illustrators.twig
@@ -1,3 +1,3 @@
 <main class="w-full column gap-row-2 section">
-    {{ cell('Illustratorium.Illustrators::all') }}
+    {{ cell('Illustratorium.Illustrators::all', [], { locale }) }}
 </main>

--- a/src/Controller/Component/CanonicalUrlComponent.php
+++ b/src/Controller/Component/CanonicalUrlComponent.php
@@ -1,0 +1,166 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller\Component;
+
+use BEdita\Core\Model\Entity\ObjectEntity;
+use Cake\Cache\Cache;
+use Cake\Controller\Component;
+use Cake\Database\Expression\CommonTableExpression;
+use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Query\SelectQuery;
+use Cake\Database\StatementInterface;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\Query;
+
+/**
+ * Component to find the canonical URL for an object.
+ */
+class CanonicalUrlComponent extends Component
+{
+    use LocatorAwareTrait;
+
+    /**
+     * @inheritDoc
+     */
+    protected $_defaultConfig = [
+        'statusLevel' => null,
+        'propertyField' => 'extra',
+        'propertyName' => 'public_url',
+        'cache' => 'canonical_urls',
+    ];
+
+    /**
+     * Get the frontend URL for the canonical tree position of an object.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $object The object we're looking for.
+     * @param string $propertyField The field where the frontend URL is stored.
+     * @param string $propertyName The property name where the frontend URL is stored.
+     * @return string|null
+     */
+    public function getCanonicalFrontendUrl(ObjectEntity $object, string $propertyField, string $propertyName): string|null
+    {
+        /** @var \BEdita\Core\Model\Table\TreesTable $trees */
+        $trees = $this->fetchTable('Trees');
+        $frontendUrl = new FunctionExpression('JSON_UNQUOTE', [new FunctionExpression('JSON_EXTRACT', [
+            $trees->Objects->aliasField($propertyField) => 'identifier',
+            sprintf('$.%s', $propertyName),
+        ])]);
+
+        /** @var \Cake\ORM\Query\SelectQuery $query */
+        $query = $trees->find();
+        $query = $query
+            ->useReadRole()
+            ->disableHydration()
+            ->with(
+                fn (CommonTableExpression $cte, SelectQuery $query): CommonTableExpression => $cte
+                    ->recursive()
+                    ->name('paths')
+                    ->field(['canonical', 'frontend_url', 'parent_id'])
+                    ->query(
+                        $trees->find()
+                            ->select([
+                                $trees->aliasField('canonical'),
+                                $frontendUrl,
+                                $trees->aliasField('parent_id'),
+                            ])
+                            ->innerJoinWith(
+                                $trees->Objects->getName(),
+                                fn (Query $query): Query => $query->find('available'),
+                            )
+                            ->where([$trees->aliasField('object_id') => $object->id])
+
+                            ->unionAll(
+                                $trees->find()
+                                    ->select([
+                                        'paths.canonical',
+                                        $frontendUrl,
+                                        $trees->aliasField('parent_id'),
+                                    ])
+                                    ->innerJoinWith(
+                                        $trees->Objects->getName(),
+                                        fn (Query $query): Query => $query->find('available'),
+                                    )
+                                    ->innerJoin(
+                                        'paths',
+                                        [fn (QueryExpression $exp): QueryExpression => $exp
+                                            ->equalFields('paths.parent_id', $trees->aliasField('object_id'))],
+                                    ),
+                            ),
+                    ),
+            )
+            ->select(fn (Query $query): array => [
+                'frontend_url' => 'paths.frontend_url',
+                'canonical' => $query->func()
+                    ->aggregate('BIT_OR', ['paths.canonical' => 'identifier'], return: 'boolean'),
+            ])
+            ->from('paths')
+            /*
+             * We now filter, out of all tree positions we've walked up considering only published parents at each step,
+             * only those where we were able to find an ancestor node at a certain point that has the frontend URL set.
+             */
+            ->where(fn (QueryExpression $exp): QueryExpression => $exp->isNotNull('paths.frontend_url'))
+            /*
+             * We now sort by canonical position first.
+             * Also, if an object is present multiple times in the same frontend, for the sake of the canonical URL
+             * we consider it to be a single position.
+             */
+            ->group('paths.frontend_url')
+            ->orderDesc('canonical')
+            /*
+             * Limit to 2 results because:
+             *  - if zero rows are returned, we cannot find a canonical URL.
+             *  - if one row is returned, that should be considered the canonical URL regardless of whether it was
+             *      explicitly set as canonical or not.
+             *  - if two rows are returned and the first of them is explicitly set as canonical, that should be
+             *      considered the canonical URL, and we're not interested in how many more positions there are.
+             *  - if two rows are returned and none of them is explicitly set as canonical, we cannot decide which
+             *      of them is the canonical one, and this is true regardless of how many more positions there may be.
+             */
+            ->limit(2);
+
+        /** @var array{frontend_url: string, canonical: bool}[]|false $results */
+        $results = Cache::remember(
+            $object->uname,
+            fn (): array|bool => $query->execute()->fetchAll(StatementInterface::FETCH_TYPE_ASSOC),
+            $this->getConfigOrFail('cache'),
+        );
+
+        if (empty($results)) {
+            return null;
+        }
+
+        ['frontend_url' => $frontendUrl, 'canonical' => $canonical] = array_shift($results);
+        if ($canonical || empty($results)) {
+            return $frontendUrl;
+        }
+
+        return null;
+    }
+
+    /**
+     * Build the canonical URL for an object.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $object The object we're looking for.
+     * @return string|null
+     */
+    public function buildCanonicalUrl(ObjectEntity $object): string|null
+    {
+        $propertyField = $this->getConfigOrFail('propertyField');
+        $propertyName = $this->getConfigOrFail('propertyName');
+
+        if (!empty($object[$propertyField][$propertyName])) {
+            // This case should cover root folders only.
+            // object has a frontend URL set, return it immediately.
+            return $object[$propertyField][$propertyName];
+        }
+
+        $canonicalFrontendUrl = $this->getCanonicalFrontendUrl($object, $propertyField, $propertyName);
+        if ($canonicalFrontendUrl === null) {
+            return null;
+        }
+
+        return sprintf('%s/objects/%s', rtrim($canonicalFrontendUrl, '/'), $object->uname);
+    }
+}


### PR DESCRIPTION
Use canonical urls for objects from a different publication, by checking root folder's `public_url` (or `staging_url`) fields in `extra` data.

Bonus: pass `locale` to illustrators cells.